### PR TITLE
fix jsx whitespace handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export default () => {
           return createVNode(<ts.JsxSelfClosingElement>node);
 
         case ts.SyntaxKind.JsxText:
-          var text = handleWhiteSpace(node.getText());
+          var text = handleWhiteSpace(node.getFullText());
 
           if (text !== "") {
             return ts.createLiteral(text);

--- a/tests/cases/whitespaceAfterClosingTag.tsx
+++ b/tests/cases/whitespaceAfterClosingTag.tsx
@@ -1,0 +1,3 @@
+<p>
+	<span>hello</span> world
+</p>

--- a/tests/references/whitespaceAfterClosingTag.jsx
+++ b/tests/references/whitespaceAfterClosingTag.jsx
@@ -1,0 +1,4 @@
+var Inferno = require("inferno");
+var createTextVNode = Inferno.createTextVNode;
+var createVNode = Inferno.createVNode;
+createVNode(1, "p", null, [createVNode(1, "span", null, createTextVNode("hello"), 2), createTextVNode(" world")], 4);


### PR DESCRIPTION
Given some code like `<span>hello</span> world`, `getText` returns `world` instead of ` world` so when the transformation is done we end up  with the equivalent of `helloworld` instead of `hello world`.