### PR TITLE
use `import` syntax to import Inferno namespace

### DIFF
--- a/src/updateSourceFile.ts
+++ b/src/updateSourceFile.ts
@@ -30,17 +30,15 @@ export default (sourceFile: ts.SourceFile, context) => {
   }
 
   statements.unshift(
-    ts.createVariableStatement(undefined, [
-      ts.createVariableDeclaration(
-        "Inferno",
+    ts.createImportDeclaration(
+      undefined,
+      undefined,
+      ts.createImportClause(
         undefined,
-        ts.createCall(
-          ts.createIdentifier("require"),
-          [],
-          [ts.createLiteral("inferno")]
-        )
-      )
-    ])
+        ts.createNamespaceImport(ts.createIdentifier("Inferno"))
+      ),
+      ts.createLiteral("inferno")
+    )
   );
 
   return ts.updateSourceFileNode(sourceFile, statements);

--- a/tests/references/Component1.jsx
+++ b/tests/references/Component1.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com, { "children": a });

--- a/tests/references/Component2.jsx
+++ b/tests/references/Component2.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com, { "children": [a,
         b,

--- a/tests/references/Component3.jsx
+++ b/tests/references/Component3.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createComponentVNode = Inferno.createComponentVNode;
 var createVNode = Inferno.createVNode;

--- a/tests/references/Component4.jsx
+++ b/tests/references/Component4.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Context.Provider);

--- a/tests/references/advancedExpression.jsx
+++ b/tests/references/advancedExpression.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 var createVNode = Inferno.createVNode;
 function MyComponent(props) {

--- a/tests/references/advancedWithImports.jsx
+++ b/tests/references/advancedWithImports.jsx
@@ -14,7 +14,7 @@ var __extends = (this && this.__extends) || (function () {
         if (v !== undefined) module.exports = v;
     }
     else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "inferno", "inferno-component", "./components/Incrementer"], factory);
+        define(["require", "exports", "inferno", "inferno", "inferno-component", "./components/Incrementer"], factory);
     }
 })(function (require, exports) {
     "use strict";

--- a/tests/references/childrenProps1.jsx
+++ b/tests/references/childrenProps1.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, createTextVNode("test"), 2);

--- a/tests/references/childrenProps10.jsx
+++ b/tests/references/childrenProps10.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "foo");

--- a/tests/references/childrenProps11.jsx
+++ b/tests/references/childrenProps11.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Context.Provider, { "children": "test" });

--- a/tests/references/childrenProps2.jsx
+++ b/tests/references/childrenProps2.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, createTextVNode("ab"), 2);

--- a/tests/references/childrenProps3.jsx
+++ b/tests/references/childrenProps3.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, createTextVNode("ab"), 2);

--- a/tests/references/childrenProps4.jsx
+++ b/tests/references/childrenProps4.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com, { "children": "test" });

--- a/tests/references/childrenProps5.jsx
+++ b/tests/references/childrenProps5.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com, { "children": "ab" });

--- a/tests/references/childrenProps6.jsx
+++ b/tests/references/childrenProps6.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com, { "children": "ab" });

--- a/tests/references/childrenProps7.jsx
+++ b/tests/references/childrenProps7.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, Com);

--- a/tests/references/childrenProps8.jsx
+++ b/tests/references/childrenProps8.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createComponentVNode = Inferno.createComponentVNode;
 var createVNode = Inferno.createVNode;

--- a/tests/references/childrenProps9.jsx
+++ b/tests/references/childrenProps9.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "foo", null, createVNode(1, "span", null, createTextVNode("b"), 2), 2);

--- a/tests/references/div.jsx
+++ b/tests/references/div.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div");

--- a/tests/references/divSelfClosed.jsx
+++ b/tests/references/divSelfClosed.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div");

--- a/tests/references/divWithAttributeReturningJSX.jsx
+++ b/tests/references/divWithAttributeReturningJSX.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, null, 1, { "foo": function () { return (createVNode(1, "div", null, null, 1, { "bar": true })); } });

--- a/tests/references/divWithChild.jsx
+++ b/tests/references/divWithChild.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, createTextVNode("1"), 2);

--- a/tests/references/divWithChildAndClassExpression.jsx
+++ b/tests/references/divWithChildAndClassExpression.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", "first" + "second", createTextVNode("1"), 2);

--- a/tests/references/divWithChildAndClassName.jsx
+++ b/tests/references/divWithChildAndClassName.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", "first second", createTextVNode("1"), 2);

--- a/tests/references/divWithChildExpression.jsx
+++ b/tests/references/divWithChildExpression.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, test, 0);

--- a/tests/references/divWithChildExpressionAdvanced.jsx
+++ b/tests/references/divWithChildExpressionAdvanced.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, false && [
     createVNode(1, "div"),

--- a/tests/references/divWithClassAsVariable.jsx
+++ b/tests/references/divWithClassAsVariable.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", variable, createTextVNode("1"), 2);

--- a/tests/references/divWithEvents.jsx
+++ b/tests/references/divWithEvents.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", variable, createTextVNode("1"), 2, { "id": "test", "onClick": func });

--- a/tests/references/divWithNoAssignedAttributes.jsx
+++ b/tests/references/divWithNoAssignedAttributes.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, null, 1, { "foo": true, "Bar": true, "STAR": true });

--- a/tests/references/functionalComponentLifeCycle.jsx
+++ b/tests/references/functionalComponentLifeCycle.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, FunctionalComponent, null, null, { "onComponentDidMount": mounted });

--- a/tests/references/htmlFor.jsx
+++ b/tests/references/htmlFor.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "label", null, createVNode(64, "input", null, null, 1, { "id": id, "name": name, "value": value, "onChange": onChange, "onInput": onInput, "onKeyup": onKeyup, "onFocus": onFocus, "onClick": onClick, "type": "number", "pattern": "[0-9]+([,\\.][0-9]+)?", "inputMode": "numeric", "min": minimum }), 2, { "for": id });

--- a/tests/references/specialFlags1.jsx
+++ b/tests/references/specialFlags1.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, magic, 8);

--- a/tests/references/specialFlags2.jsx
+++ b/tests/references/specialFlags2.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, magic, 2);

--- a/tests/references/specialFlags3.jsx
+++ b/tests/references/specialFlags3.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, createTextVNode("text"), 2);

--- a/tests/references/specialFlags4.jsx
+++ b/tests/references/specialFlags4.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(1, "div", null, test, 4);

--- a/tests/references/specialFlags5.jsx
+++ b/tests/references/specialFlags5.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(2049, "div");

--- a/tests/references/spreadAttribute1.jsx
+++ b/tests/references/spreadAttribute1.jsx
@@ -6,7 +6,7 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
     }
     return t;
 };
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var normalizeProps = Inferno.normalizeProps;
 var createVNode = Inferno.createVNode;
 normalizeProps(createVNode(1, "div", null, null, 1, __assign({}, props, { "foo": "bar" })));

--- a/tests/references/spreadAttribute2.jsx
+++ b/tests/references/spreadAttribute2.jsx
@@ -6,7 +6,7 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
     }
     return t;
 };
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var normalizeProps = Inferno.normalizeProps;
 var createVNode = Inferno.createVNode;
 normalizeProps(createVNode(1, "div", null, null, 1, __assign({}, this.props, { "foo": "bar" })));

--- a/tests/references/svgAttributeFillOpacity.jsx
+++ b/tests/references/svgAttributeFillOpacity.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(32, "svg", null, createVNode(1, "rect", null, null, 1, { "fill-opacity": "1" }), 2);

--- a/tests/references/svgAttributeStrokeWidth.jsx
+++ b/tests/references/svgAttributeStrokeWidth.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(32, "svg", null, createVNode(1, "rect", null, null, 1, { "stroke-width": "1px" }), 2);

--- a/tests/references/svgAttributeXlinkHref.jsx
+++ b/tests/references/svgAttributeXlinkHref.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
 createVNode(32, "svg", null, createVNode(1, "use", null, null, 1, { "xlink:href": "#tester" }), 2);

--- a/tests/references/unknownClass.jsx
+++ b/tests/references/unknownClass.jsx
@@ -1,3 +1,3 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createComponentVNode = Inferno.createComponentVNode;
 createComponentVNode(2, UnkownClass, { "className": "first second", "children": "1" });

--- a/tests/references/whitespaceAfterClosingTag.jsx
+++ b/tests/references/whitespaceAfterClosingTag.jsx
@@ -1,4 +1,4 @@
-var Inferno = require("inferno");
+import * as Inferno from "inferno";
 var createTextVNode = Inferno.createTextVNode;
 var createVNode = Inferno.createVNode;
 createVNode(1, "p", null, [createVNode(1, "span", null, createTextVNode("hello"), 2), createTextVNode(" world")], 4);


### PR DESCRIPTION
Currently `ts-transform-inferno` always import `Inferno` namespace by using commonjs syntax (whatever user set the `module` in tsconfig.json). This will break in Rollup (Rollup enforce using esm syntax).
I've test usage in webpack and fusebox, both of them works correctly.
And this PR also fix issue #1 