### PR TITLE
Text: Unescape HTML entities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,18 @@ export default () => {
           let text = handleWhiteSpace(node.getFullText())
 
           if (text !== '') {
-            return ts.createLiteral(text)
+            /**
+             * TypeScript internal module, src/compiler/transformers/jsx.ts,
+             * unescapes HTML entities such as &nbsp; in JSX text that is
+             * directly inside an element or a fragment.
+             */
+            return ts.createLiteral(
+              JSON.parse(
+                ts
+                  .transpile(`<>${text}</>`, { jsx: ts.JsxEmit.React })
+                  .replace(/^[\s\S]*?("[\s\S]*")[\s\S]*?$/, '$1')
+              )
+            )
           }
           break
 

--- a/tests/cases/text1.tsx
+++ b/tests/cases/text1.tsx
@@ -1,1 +1,6 @@
-<div>{a}<div>1</div></div>
+<div>
+  {a}
+  <div>1</div>
+  &gt;&#62;&nbsp;\u00a0&#160;\u00A0
+  <div>{"&gt;&#62;&nbsp;\u00a0&#160;\u00A0"}</div>
+</div>;

--- a/tests/references/text1.jsx
+++ b/tests/references/text1.jsx
@@ -1,3 +1,3 @@
 import * as Inferno from "inferno";
 var createVNode = Inferno.createVNode;
-createVNode(1, "div", null, [a, createVNode(1, "div", null, "1", 16)], 0);
+createVNode(1, "div", null, [a, createVNode(1, "div", null, "1", 16), ">>\u00A0\\u00a0\u00A0\\u00A0", createVNode(1, "div", null, "&gt;&#62;&nbsp;\u00a0&#160;\u00A0", 0)], 0);


### PR DESCRIPTION
Same result for text as you'd get in "react" JSX mode with createElement pragma.