### PR TITLE
Remove unused imports

### DIFF
--- a/src/updateSourceFile.ts
+++ b/src/updateSourceFile.ts
@@ -16,33 +16,41 @@ function createVarStatement(name: string) {
 export default (sourceFile: ts.SourceFile, context) => {
   let statements = [...sourceFile.statements];
 
+  let shouldAddImport = false;
+
   if (context["createFragment"]) {
+    shouldAddImport = true;
     statements.unshift(createVarStatement("createFragment"));
   }
   if (context["createVNode"]) {
+    shouldAddImport = true;
     statements.unshift(createVarStatement("createVNode"));
   }
   if (context["createComponentVNode"]) {
+    shouldAddImport = true;
     statements.unshift(createVarStatement("createComponentVNode"));
   }
   if (context["createTextVNode"]) {
+    shouldAddImport = true;
     statements.unshift(createVarStatement("createTextVNode"));
   }
   if (context["normalizeProps"]) {
+    shouldAddImport = true;
     statements.unshift(createVarStatement("normalizeProps"));
   }
 
-  statements.unshift(
-    ts.createImportDeclaration(
-      undefined,
-      undefined,
-      ts.createImportClause(
+  if (shouldAddImport) {
+    statements.unshift(
+      ts.createImportDeclaration(
         undefined,
-        ts.createNamespaceImport(ts.createIdentifier("Inferno"))
-      ),
-      ts.createLiteral("inferno")
-    )
-  );
-
+        undefined,
+        ts.createImportClause(
+          undefined,
+          ts.createNamespaceImport(ts.createIdentifier("Inferno"))
+        ),
+        ts.createLiteral("inferno")
+      )
+    );
+  }
   return ts.updateSourceFileNode(sourceFile, statements);
 };


### PR DESCRIPTION
Transform generates inferno imports for each file. This change removes unused inferno imports from files where jsx is not used.